### PR TITLE
Addition of save game patches, enables save game compatability

### DIFF
--- a/SaveGamePatches/NewWorkType.xml
+++ b/SaveGamePatches/NewWorkType.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>//workSettings/priorities/vals</xpath>
+    <value>
+   	  <li>0</li>
+    </value>
+  </Operation>
+</Patch>


### PR DESCRIPTION
I've added a save game patch for the additional work type. Now with my [Save Game Patches](https://github.com/CBornholdt/SaveGamePatches.git) mod loaded, you can try this mod on any saved game. 

FYI mod load order does not matter with my Save Game Patches mod.