### PR TITLE
bug fix restrict to training area without main restrict area

### DIFF
--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -210,7 +210,7 @@ namespace FluffyManager
 
         private void DoAreaRestrictions( ref bool actionTaken )
         {
-            if ( RestrictToArea )
+            
                 for ( var i = 0; i < Utilities_Livestock.AgeSexArray.Length; i++ )
                     foreach ( var p in Trigger.pawnKind.GetTame( manager, Utilities_Livestock.AgeSexArray[i] ) )
                         // slaughter
@@ -231,8 +231,8 @@ namespace FluffyManager
                             }
                         }
 
-                        // all
-                        else if ( p.playerSettings.AreaRestriction != RestrictArea[i] )
+                        // default areas
+                        else if ( p.playerSettings.AreaRestriction != RestrictArea[i] && RestrictToArea)
                         {
                             actionTaken                      = true;
                             p.playerSettings.AreaRestriction = RestrictArea[i];


### PR DESCRIPTION
Currently, if you don't select "restrict to areas" in the GUI you can still send the animals for slaughter and training to another area, however this does not work.
With the fix, the animals are sent to training and slaughter, even though they have not been "restricted to area" into the 4 zones.

The alternative fix was to disable the other UI blocks unless the top "restrict to areas" is also disabled. I was not sure of the original intent, though.