### PR TITLE
Add AllWork tag to Managing WorkTypeDef

### DIFF
--- a/Defs/WorkTypeDefs/WorkType_Managing.xml
+++ b/Defs/WorkTypeDefs/WorkType_Managing.xml
@@ -15,6 +15,7 @@
 		</relevantSkills>
 		<workTags>
 			<li>Intellectual</li>
+			<li>AllWork</li>
 		</workTags>
 	</WorkTypeDef>
 


### PR DESCRIPTION
"AllWork" is a tag which is used to let Royalty's "Lazy Guests" who don't do any work know what is and isn't work. For whatever reason Tynan chose to define "AllWork" explicitly for every job that exists except two, instead of just saying Bedrest and Patient are "NotWork" or something. As a result, every modded WorkTypeDef which represents labor of any sort needs these tags added, or else you can make guests do it which is kind of an exploit.

Regardless, unused tags don't cause any issues as far as I've been able to determine, so this should be a perfectly backwards compatible fix too, with or without Royalty.