### PR TITLE
Restrict Animals That Are Hungry

### DIFF
--- a/Languages/English/Keyed/Manager_Keyed.xml
+++ b/Languages/English/Keyed/Manager_Keyed.xml
@@ -194,10 +194,12 @@
   <FML.TrainYoung>Train young animals</FML.TrainYoung>
   <FML.SendToSlaughterArea>Restrict animals marked for slaughter</FML.SendToSlaughterArea>
   <FML.SendToSlaughterArea.Tip>Restrict animals designated for slaughtering to a specific area</FML.SendToSlaughterArea.Tip>
+  <FML.SendToHungryArea>Restrict animals that are hungry</FML.SendToHungryArea>
+  <FML.SendToHungryArea.Tip>Restrict animals that are hungry to a specific area</FML.SendToHungryArea.Tip>
   <FML.SendToMilkingArea>Restrict animals ready to be milked</FML.SendToMilkingArea>
-  <FML.SendToMilkingArea.Tip>Restrict animals with milk fullness above 94% to a specific area.</FML.SendToMilkingArea.Tip>
+  <FML.SendToMilkingArea.Tip>Restrict animals ready to be milked to a specific area.</FML.SendToMilkingArea.Tip>
   <FML.SendToShearingArea>Restrict animals ready to be sheared</FML.SendToShearingArea>
-  <FML.SendToShearingArea.Tip>Restrict animals with shearing fullness above 94% to a specific area</FML.SendToShearingArea.Tip>
+  <FML.SendToShearingArea.Tip>Restrict animals ready to be sheared to a specific area</FML.SendToShearingArea.Tip>
   <FM.Livestock.TargetCountsHeader>Target counts</FM.Livestock.TargetCountsHeader>
   <FM.Livestock.AreaRestrictionsHeader>Area restrictions</FM.Livestock.AreaRestrictionsHeader>
   <FM.Livestock.TrainingHeader>Training</FM.Livestock.TrainingHeader>

--- a/Source/Helpers/Livestock/Utilities_Livestock.cs
+++ b/Source/Helpers/Livestock/Utilities_Livestock.cs
@@ -399,11 +399,11 @@ namespace FluffyManager
             return Mathf.CeilToInt( ( 1 - comp.Fullness ) / growthRatePerTick );
         }
 
-        public static bool Hungry( this Pawn p )
+        public static int TicksUntilStarving( this Pawn pawn )
         {
-            //perhaps, like TicksTillHarvestable, this should estimate whether or not the animal will
-            //hit 0 food need before the next manage job interval.
-            return (p.needs.food.CurLevel <= 0.1f);
+            // this isn't perfect. we assume this is linear when it isn't. the real calculation is more complicated.
+            // check out "Need_Food.FoodFallPerTickAssumingCategory(...)" for more details
+            return Mathf.CeilToInt(pawn.needs.food.CurLevel / pawn.needs.food.FoodFallPerTick);
         }
 
         public static bool VisiblyPregnant( this Pawn pawn )

--- a/Source/Helpers/Livestock/Utilities_Livestock.cs
+++ b/Source/Helpers/Livestock/Utilities_Livestock.cs
@@ -399,6 +399,13 @@ namespace FluffyManager
             return Mathf.CeilToInt( ( 1 - comp.Fullness ) / growthRatePerTick );
         }
 
+        public static bool Hungry( this Pawn p )
+        {
+            //perhaps, like TicksTillHarvestable, this should estimate whether or not the animal will
+            //hit 0 food need before the next manage job interval.
+            return (p.needs.food.CurLevel <= 0.1f);
+        }
+
         public static bool VisiblyPregnant( this Pawn pawn )
         {
             return pawn?.health.hediffSet.GetHediffs<Hediff_Pregnant>().Any( hp => hp.Visible ) ?? false;

--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -316,7 +316,7 @@ namespace FluffyManager
             Scribe_References.Look( ref MilkArea, "MilkArea" );
             Scribe_References.Look( ref ShearArea, "ShearArea" );
             Scribe_References.Look( ref TrainingArea, "TrainingArea" );
-            Scribe_References.Look(ref HungryArea, "HungryArea");
+            Scribe_References.Look( ref HungryArea, "HungryArea" );
             Scribe_References.Look( ref Master, "Master" );
             Scribe_References.Look( ref Trainer, "Trainer" );
             Scribe_Collections.Look( ref RestrictArea, "AreaRestrictions", LookMode.Reference );

--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -519,7 +519,8 @@ namespace FluffyManager
                     }
 
                     // hungry
-                    else if (SendToHungryArea && p.Hungry())
+                    else if ( SendToHungryArea && 
+                              p.TicksUntilStarving() < UpdateInterval.ticks )
                     {
                         if (p.playerSettings.AreaRestriction != HungryArea)
                         {

--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -32,11 +32,13 @@ namespace FluffyManager
         public                  bool             SendToMilkingArea;
         public                  bool             SendToShearingArea;
         public                  bool             SendToSlaughterArea;
+        public                  bool             SendToHungryArea;
         public                  bool             SendToTrainingArea;
         public                  bool             SetFollow;
         public                  Area             ShearArea;
         public                  Area             SlaughterArea;
         public                  Area             TameArea;
+        public                  Area             HungryArea;
         public                  Pawn             Trainer;
         public                  MasterMode       Trainers;
         public                  TrainingTracker  Training;
@@ -90,6 +92,10 @@ namespace FluffyManager
             // set up training area
             SendToTrainingArea = false;
             TrainingArea       = null;
+
+            // set up hungry area
+            SendToHungryArea = false;
+            HungryArea       = null;
 
             // taming
             TryTameMore = false;
@@ -310,6 +316,7 @@ namespace FluffyManager
             Scribe_References.Look( ref MilkArea, "MilkArea" );
             Scribe_References.Look( ref ShearArea, "ShearArea" );
             Scribe_References.Look( ref TrainingArea, "TrainingArea" );
+            Scribe_References.Look(ref HungryArea, "HungryArea");
             Scribe_References.Look( ref Master, "Master" );
             Scribe_References.Look( ref Trainer, "Trainer" );
             Scribe_Collections.Look( ref RestrictArea, "AreaRestrictions", LookMode.Reference );
@@ -325,6 +332,7 @@ namespace FluffyManager
             Scribe_Values.Look( ref SendToMilkingArea, "SendToMilkingArea" );
             Scribe_Values.Look( ref SendToShearingArea, "SendToShearingArea" );
             Scribe_Values.Look( ref SendToTrainingArea, "SendToTrainingArea" );
+            Scribe_Values.Look( ref SendToHungryArea, "SendToHungryArea");
             Scribe_Values.Look( ref TryTameMore, "TryTameMore" );
             Scribe_Values.Look( ref SetFollow, "SetFollow", true );
             Scribe_Values.Look( ref FollowDrafted, "FollowDrafted", true );
@@ -508,6 +516,16 @@ namespace FluffyManager
                     {
                         actionTaken                      = p.playerSettings.AreaRestriction != SlaughterArea;
                         p.playerSettings.AreaRestriction = SlaughterArea;
+                    }
+
+                    // hungry
+                    else if (SendToHungryArea && p.Hungry())
+                    {
+                        if (p.playerSettings.AreaRestriction != HungryArea)
+                        {
+                            actionTaken = true;
+                            p.playerSettings.AreaRestriction = HungryArea;
+                        }
                     }
 
                     // milking

--- a/Source/ManagerTabs/ManagerTab_Livestock.cs
+++ b/Source/ManagerTabs/ManagerTab_Livestock.cs
@@ -557,9 +557,7 @@ namespace FluffyManager
                 }
             }
 
-            //do we assume that all animals can get hungry and eat, or check for existence of something?
-            //if (_selectedCurrent.Trigger.pawnKind.invFoodDef != null)
-            if (true)
+            if (_selectedCurrent.Trigger.pawnKind.RaceProps.EatsFood)
             {
                 var sendToHungryAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
                 pos.y += ListEntryHeight;

--- a/Source/ManagerTabs/ManagerTab_Livestock.cs
+++ b/Source/ManagerTabs/ManagerTab_Livestock.cs
@@ -557,6 +557,26 @@ namespace FluffyManager
                 }
             }
 
+            //do we assume that all animals can get hungry and eat, or check for existence of something?
+            //if (_selectedCurrent.Trigger.pawnKind.invFoodDef != null)
+            if (true)
+            {
+                var sendToHungryAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
+                pos.y += ListEntryHeight;
+                DrawToggle(sendToHungryAreaRect,
+                            "FML.SendToHungryArea".Translate(),
+                            "FML.SendToHungryArea.Tip".Translate(),
+                            ref _selectedCurrent.SendToHungryArea);
+
+                if (_selectedCurrent.SendToHungryArea)
+                {
+                    var hungryAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
+                    AreaAllowedGUI.DoAllowedAreaSelectors(hungryAreaRect, ref _selectedCurrent.HungryArea,
+                                                           manager);
+                    pos.y += ListEntryHeight;
+                }
+            }
+
             if ( _selectedCurrent.Trigger.pawnKind.Shearable() )
             {
                 var sendToShearingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );

--- a/Source/ManagerTabs/ManagerTab_Livestock.cs
+++ b/Source/ManagerTabs/ManagerTab_Livestock.cs
@@ -539,24 +539,6 @@ namespace FluffyManager
                        color: Color.grey );
             }
 
-            if ( _selectedCurrent.Trigger.pawnKind.Milkable() )
-            {
-                var sendToMilkingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );
-                pos.y += ListEntryHeight;
-                DrawToggle( sendToMilkingAreaRect,
-                            "FML.SendToMilkingArea".Translate(),
-                            "FML.SendToMilkingArea.Tip".Translate(),
-                            ref _selectedCurrent.SendToMilkingArea );
-
-                if ( _selectedCurrent.SendToMilkingArea )
-                {
-                    var milkingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );
-                    AreaAllowedGUI.DoAllowedAreaSelectors( milkingAreaRect, ref _selectedCurrent.MilkArea,
-                                                           manager );
-                    pos.y += ListEntryHeight;
-                }
-            }
-
             if (_selectedCurrent.Trigger.pawnKind.RaceProps.EatsFood)
             {
                 var sendToHungryAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
@@ -571,6 +553,24 @@ namespace FluffyManager
                     var hungryAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
                     AreaAllowedGUI.DoAllowedAreaSelectors(hungryAreaRect, ref _selectedCurrent.HungryArea,
                                                            manager);
+                    pos.y += ListEntryHeight;
+                }
+            }
+
+            if ( _selectedCurrent.Trigger.pawnKind.Milkable() )
+            {
+                var sendToMilkingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );
+                pos.y += ListEntryHeight;
+                DrawToggle( sendToMilkingAreaRect,
+                            "FML.SendToMilkingArea".Translate(),
+                            "FML.SendToMilkingArea.Tip".Translate(),
+                            ref _selectedCurrent.SendToMilkingArea );
+
+                if ( _selectedCurrent.SendToMilkingArea )
+                {
+                    var milkingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );
+                    AreaAllowedGUI.DoAllowedAreaSelectors( milkingAreaRect, ref _selectedCurrent.MilkArea,
+                                                           manager );
                     pos.y += ListEntryHeight;
                 }
             }


### PR DESCRIPTION
![restrictHungryExample](https://user-images.githubusercontent.com/7416299/97839387-1eb60800-1cb0-11eb-9f8c-030ca559695c.png)

Specifically restrict animals that are hungry. A few cases:

* An animal was restricted for Training or Milk/Shearing, but the Handlers are busy, and it is starving. Let it out to eat, and come back later.
* The animal has access to food, but is being dumb. It can't find food close enough, or it went to bed without enough food, and started staving during the night. Wake it up and send it to the freezer immediately to eat something. Helps prevent miscarriages too!

Notes on the implementation:

* We assume the ticks until starving is linear based on current hunger level, which is absolutely not true. The reality is more complex. We assume their food need will fall linearly based on its current rate, when in reality in slows down closer to the end. This means we are currently assuming animals are hungry sooner than we need to.