### PR TITLE
Restrict Animals That Are Sick / Need Tending

### DIFF
--- a/Languages/English/Keyed/Manager_Keyed.xml
+++ b/Languages/English/Keyed/Manager_Keyed.xml
@@ -198,6 +198,8 @@
   <FML.SendToMilkingArea.Tip>Restrict animals with milk fullness above 94% to a specific area.</FML.SendToMilkingArea.Tip>
   <FML.SendToShearingArea>Restrict animals ready to be sheared</FML.SendToShearingArea>
   <FML.SendToShearingArea.Tip>Restrict animals with shearing fullness above 94% to a specific area</FML.SendToShearingArea.Tip>
+  <FML.SendToSickArea>Restrict animals that are sick/injured</FML.SendToSickArea>
+  <FML.SendToSickArea.Tip>Restrict animals that are sick/injured to a specific area</FML.SendToSickArea.Tip>
   <FM.Livestock.TargetCountsHeader>Target counts</FM.Livestock.TargetCountsHeader>
   <FM.Livestock.AreaRestrictionsHeader>Area restrictions</FM.Livestock.AreaRestrictionsHeader>
   <FM.Livestock.TrainingHeader>Training</FM.Livestock.TrainingHeader>

--- a/Source/Helpers/Livestock/Utilities_Livestock.cs
+++ b/Source/Helpers/Livestock/Utilities_Livestock.cs
@@ -404,6 +404,14 @@ namespace FluffyManager
             return pawn?.health.hediffSet.GetHediffs<Hediff_Pregnant>().Any( hp => hp.Visible ) ?? false;
         }
 
+        public static bool AnimalIsSick( this Pawn pawn )
+        {
+            if (pawn.health.hediffSet.HasImmunizableNotImmuneHediff()) { return true; }
+            if (pawn.health.HasHediffsNeedingTend()) { return true; }
+            if (!pawn.health.capacities.CapableOf(PawnCapacityDefOf.Moving)) { return true; }
+            return false;
+        }
+
         private static bool _milkable( this Pawn pawn )
         {
             var    comp                = pawn?.TryGetComp<CompMilkable>();

--- a/Source/ManagerJobs/ManagerJob_Livestock.cs
+++ b/Source/ManagerJobs/ManagerJob_Livestock.cs
@@ -29,12 +29,14 @@ namespace FluffyManager
         public                  bool             RespectBonds = true;
         public                  List<Area>       RestrictArea;
         public                  bool             RestrictToArea;
+        public                  bool             SendToSickArea;
         public                  bool             SendToMilkingArea;
         public                  bool             SendToShearingArea;
         public                  bool             SendToSlaughterArea;
         public                  bool             SendToTrainingArea;
         public                  bool             SetFollow;
         public                  Area             ShearArea;
+        public                  Area             SickArea;
         public                  Area             SlaughterArea;
         public                  Area             TameArea;
         public                  Pawn             Trainer;
@@ -78,6 +80,10 @@ namespace FluffyManager
             // set up sending animals designated for slaughter to an area (freezer)
             SendToSlaughterArea = false;
             SlaughterArea       = null;
+
+            // set up sick area
+            SendToSickArea = false;
+            SickArea = null;
 
             // set up milking area
             SendToMilkingArea = false;
@@ -306,6 +312,7 @@ namespace FluffyManager
 
             // settings, references first!
             Scribe_References.Look( ref TameArea, "TameArea" );
+            Scribe_References.Look( ref SickArea, "SickArea" );
             Scribe_References.Look( ref SlaughterArea, "SlaughterArea" );
             Scribe_References.Look( ref MilkArea, "MilkArea" );
             Scribe_References.Look( ref ShearArea, "ShearArea" );
@@ -322,6 +329,7 @@ namespace FluffyManager
             Scribe_Values.Look( ref ButcherBonded, "ButcherBonded" );
             Scribe_Values.Look( ref RestrictToArea, "RestrictToArea" );
             Scribe_Values.Look( ref SendToSlaughterArea, "SendToSlaughterArea" );
+            Scribe_Values.Look( ref SendToSickArea, "SendToSickArea" );
             Scribe_Values.Look( ref SendToMilkingArea, "SendToMilkingArea" );
             Scribe_Values.Look( ref SendToShearingArea, "SendToShearingArea" );
             Scribe_Values.Look( ref SendToTrainingArea, "SendToTrainingArea" );
@@ -509,6 +517,17 @@ namespace FluffyManager
                         actionTaken                      = p.playerSettings.AreaRestriction != SlaughterArea;
                         p.playerSettings.AreaRestriction = SlaughterArea;
                     }
+
+                    // sick
+                    else if (SendToSickArea && p.AnimalIsSick())
+                    {
+                        if (p.playerSettings.AreaRestriction != SickArea)
+                        {
+                            actionTaken = true;
+                            p.playerSettings.AreaRestriction = SickArea;
+                        }
+                    }
+
 
                     // milking
                     else if ( SendToMilkingArea                                        &&

--- a/Source/ManagerTabs/ManagerTab_Livestock.cs
+++ b/Source/ManagerTabs/ManagerTab_Livestock.cs
@@ -539,6 +539,27 @@ namespace FluffyManager
                        color: Color.grey );
             }
 
+            // i think all tamed animals can at least require tending, if not get sick
+            // if there is some def-wide tamable animal that never gets sick or needs tending
+            // like pet mechanoids or something, that condition would go here. idk what it is.
+            if (true)
+            {
+                var sendToSickAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
+                pos.y += ListEntryHeight;
+                DrawToggle(sendToSickAreaRect,
+                            "FML.SendToSickArea".Translate(),
+                            "FML.SendToSickArea.Tip".Translate(),
+                            ref _selectedCurrent.SendToSickArea);
+
+                if (_selectedCurrent.SendToSickArea)
+                {
+                    var sickAreaRect = new Rect(pos.x, pos.y, width, ListEntryHeight);
+                    AreaAllowedGUI.DoAllowedAreaSelectors(sickAreaRect, ref _selectedCurrent.SickArea,
+                                                           manager);
+                    pos.y += ListEntryHeight;
+                }
+            }
+
             if ( _selectedCurrent.Trigger.pawnKind.Milkable() )
             {
                 var sendToMilkingAreaRect = new Rect( pos.x, pos.y, width, ListEntryHeight );


### PR DESCRIPTION
### Restrict Animals That Are Sick / Need Tending

Short-circuit most of the other conditions for animals that are sick/injured, so that when 43 out of 106 Boomalopes get the Plague, your entire system doesn't break down. They stay in bed and live, instead of getting dragged all over creation and ending up dead, while the non-sick Boomalopes continue business as usual.

Note we look for immunity diseases or injuries that need tending. Once the injuries have been tended, if there's no immunity diseases, you get back up and get out of here, as long as you're capable of walking. No bed rest on my watch.

![sickAnimalFilter](https://user-images.githubusercontent.com/7416299/100695053-69ce4400-335e-11eb-9291-5ca279992183.png)
