### PR TITLE
Add FML.TrainYoung.Tip for English

### DIFF
--- a/Languages/English/Keyed/Manager_Keyed.xml
+++ b/Languages/English/Keyed/Manager_Keyed.xml
@@ -192,6 +192,7 @@
   <FML.UnassignTraining>Unassign training</FML.UnassignTraining>
   <FML.UnassignTraining.Tip>Unassign training targets for animals</FML.UnassignTraining.Tip>
   <FML.TrainYoung>Train young animals</FML.TrainYoung>
+  <FML.TrainYoung.Tip>Should young animals be marked training?</FML.TrainYoung.Tip>
   <FML.SendToSlaughterArea>Restrict animals marked for slaughter</FML.SendToSlaughterArea>
   <FML.SendToSlaughterArea.Tip>Restrict animals designated for slaughtering to a specific area</FML.SendToSlaughterArea.Tip>
   <FML.SendToMilkingArea>Restrict animals ready to be milked</FML.SendToMilkingArea>


### PR DESCRIPTION
FML.TrainYoung.Tip did not exist in the English translations file, leading to a broken toolip:

![image](https://user-images.githubusercontent.com/5238335/188528338-3c9fee43-2269-43f4-9b39-b19ad0d4eece.png)

With only a quick check, the translation key only existed previously in Russian, but I am only qualified to add an English translation.

I don't know why Github is highlighting a newline being added to the end of the file. It doesn't appear to exist for me locally, but regardless, it doesn't break XML, so I'm not worried.