### PR TITLE
Update ManagerStations_Research.xml to solve an error in developer mode

### DIFF
--- a/Languages/ChineseSimplified/DefInjected/ResearchProjectDef/ManagerStations_Research.xml
+++ b/Languages/ChineseSimplified/DefInjected/ResearchProjectDef/ManagerStations_Research.xml
@@ -2,15 +2,13 @@
 <LanguageData>
 
   <ManagingSoftware.label>基本管理软件</ManagingSoftware.label>
-  <ManagingSoftware.description>为殖民地管理开发基础软件。\n\n解锁建造带电脑的「管理办公桌」，配套的主机预装了「保证无BUG公司」出品的管理软件。
-        </ManagingSoftware.description>
+  <ManagingSoftware.description>为殖民地管理开发基础软件。\n\n解锁建造带电脑的「管理办公桌」，配套的主机预装了「保证无BUG公司」出品的管理软件。</ManagingSoftware.description>
 
   <AdvancedManagingSoftware.label>高级管理软件</AdvancedManagingSoftware.label>
   <AdvancedManagingSoftware.description>为殖民地管理开发高级的软件。\n\n解锁建造「AI管理者」。殖民地意识超级计算机预装了FluffyOS，具有完善的AI。有部分殖民者反应门会开开关关，空调系统乱套了，电熔炼器突然开启。无论如何，开发商「保证无BUG公司」绝对不是为了弄死殖民者而编写的FluffyOS。</AdvancedManagingSoftware.description>
 
   <PowerManagement.label>电力管理</PowerManagement.label>
-  <PowerManagement.description>开发管理软件来监测殖民地的电力使用情况。
-        </PowerManagement.description>
+  <PowerManagement.description>开发管理软件来监测殖民地的电力使用情况。</PowerManagement.description>
 
 
 </LanguageData>


### PR DESCRIPTION
Removing tailing white spaces for ManagingSoftware.description and PowerManagement.description for ChineseSimplified. This tailing spaces will trigger an error in developermode (the logs)
```
Config error in ManagingSoftware: description has trailing whitespace
UnityEngine.StackTraceUtility:ExtractStackTrace ()
Verse.Log:Error (string)
Verse.DefDatabase`1<Verse.ResearchProjectDef>:ErrorCheckAllDefs ()
System.Reflection.MonoMethod:Invoke (object,System.Reflection.BindingFlags,System.Reflection.Binder,object[],System.Globalization.CultureInfo)
System.Reflection.MethodBase:Invoke (object,object[])
Verse.GenGeneric:InvokeStaticMethodOnGenericType (System.Type,System.Type,string)
Verse.PlayDataLoader/<>c:<DoPlayLoad>b__4_1 (System.Type)
System.Threading.Tasks.Parallel/<>c__DisplayClass31_0`2<System.Type, object>:<ForEachWorker>b__0 (int)
System.Threading.Tasks.Parallel/<>c__DisplayClass17_0`1<object>:<ForWorker>b__1 ()
System.Threading.Tasks.Task:InnerInvoke ()
System.Threading.Tasks.Task:InnerInvokeWithArg (System.Threading.Tasks.Task)
System.Threading.Tasks.Task/<>c__DisplayClass178_0:<ExecuteSelfReplicating>b__0 (object)
System.Threading.Tasks.Task:InnerInvoke ()
System.Threading.Tasks.Task:Execute ()
System.Threading.Tasks.Task:ExecutionContextCallback (object)
System.Threading.ExecutionContext:RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool)
System.Threading.ExecutionContext:Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool)
System.Threading.Tasks.Task:ExecuteWithThreadLocal (System.Threading.Tasks.Task&)
System.Threading.Tasks.Task:ExecuteEntry (bool)
System.Threading.Tasks.Task:System.Threading.IThreadPoolWorkItem.ExecuteWorkItem ()
System.Threading.ThreadPoolWorkQueue:Dispatch ()
System.Threading._ThreadPoolWaitCallback:PerformWaitCallback ()
```